### PR TITLE
Added nginxinc to the prefix

### DIFF
--- a/rfc078-supermarket-prefix.md
+++ b/rfc078-supermarket-prefix.md
@@ -61,10 +61,11 @@ To register a prefix, fork this repository and create a Pull Request adding
 your prefix and the person or organization that will be responsible for it.
 
 * `poise` - [coderanger](https://github.com/coderanger)
-* `sigsci` - [signalsciences] (https://github.com/signalsciences)
+* `sigsci` - [signalsciences](https://github.com/signalsciences)
 * `gcp` - [googlecloudplatform](https://github.com/googlecloudplatform)
 * `fb` - [Faceboook](https://github.com/facebook)
 * `blp` - [Bloomberg](https://github.com/bloomberg)
+* `nginxinc` - [nginxinc](https://github.com/nginxinc)
 
 ## Copyright
 


### PR DESCRIPTION
This will allow for nginxinc to have the prefix for nginxinc's cookbooks.

Signed-off-by: JJ Asghar  <jj@chef.io>